### PR TITLE
Fix batch operations to preserve multiple usage/value selections

### DIFF
--- a/ui/batch_ops.py
+++ b/ui/batch_ops.py
@@ -407,9 +407,15 @@ class BatchOperationsDialog(QDialog):
                         field_value = controls['field_value']  # e.g., 'Military'
                         is_enabled = controls['value'].isChecked()  # ON or OFF
                         
-                        # Get current list
-                        old_list = getattr(item, field_type)
-                        new_list = list(old_list)  # Copy
+                        # Get the item's original list for comparison
+                        old_list = list(getattr(item, field_type))
+
+                        # If this batch already staged a change for the same field,
+                        # continue building from that staged list instead of starting over.
+                        if field_type in item_data['changes']:
+                            new_list = list(item_data['changes'][field_type]['new'])
+                        else:
+                            new_list = list(old_list)
                         
                         # Add or remove based on toggle
                         if is_enabled and field_value not in new_list:


### PR DESCRIPTION
Fixes a bug in Batch Operations where selecting multiple Usage or Value entries only preserved the final selection.

## Root Cause

Each Usage/Value change rebuilt the staged list from the item's original values instead of the already-staged batch changes, causing previous selections to be overwritten.

## Fix

Subsequent Usage/Value modifications now build from the staged list when one exists, allowing multiple additions and removals in a single batch operation.

## Tested

- Added multiple Usage entries in one operation.
- Removed multiple Usage entries in one operation.
- Added multiple Value (Tier) entries in one operation.
- Removed multiple Value entries in one operation.
- Verified mixed add/remove operations preserve existing assignments correctly.